### PR TITLE
add editor settings from language-c

### DIFF
--- a/settings/language-arduino.cson
+++ b/settings/language-arduino.cson
@@ -1,0 +1,17 @@
+'.source.arduino':
+  'editor':
+    'commentStart': '// '
+    'increaseIndentPattern': '(?x)
+       ^ .* \\{ [^}"\']* $
+      |^ .* \\( [^\\)"\']* $
+      |^ \\s* (public|private|protected): \\s* $
+      |^ \\s* @(public|private|protected) \\s* $
+      |^ \\s* \\{ \\} $
+      '
+    'decreaseIndentPattern': '(?x)
+       ^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\}
+      |^ \\s* (\\s* /[*] .* [*]/ \\s*)* \\)
+      |^ \\s* (public|private|protected): \\s* $
+      |^ \\s* @(public|private|protected) \\s* $
+      '
+    'foldEndPattern': '(?<!\\*)\\*\\*/|^\\s*\\}'


### PR DESCRIPTION
This pull request pulls in the scoped editor settings from the language-c package. This adds some niceties like automatic indenting during class definitions, but most of the reason I did it was for [CMD]+/ block commenting with `// `, which I find way more convenient than `/* */`.

![arduino-comments](https://cloud.githubusercontent.com/assets/2963448/7098294/b303d740-dfac-11e4-87a8-34bdd35d85a3.gif)
