### PR TITLE
Add strings and arrays to the storage.type classification

### DIFF
--- a/grammars/arduino.cson
+++ b/grammars/arduino.cson
@@ -15,7 +15,7 @@
   }
 
   {
-    'match': '\\b(boolean|byte|word)\\b'
+    'match': '\\b(boolean|byte|word|string|array)\\b'
     'name': 'storage.type.arduino'
   }
   {


### PR DESCRIPTION
I understand that strings and arrays are not primitive data types, however they do fall under the "storage.type" classification.